### PR TITLE
Minor update to chapter 3 converter and transform examples.

### DIFF
--- a/chapter3/converter/src/main/java/camelinaction/PurchaseOrderConverter.java
+++ b/chapter3/converter/src/main/java/camelinaction/PurchaseOrderConverter.java
@@ -21,8 +21,8 @@ public final class PurchaseOrderConverter {
         s = s.replaceAll("##START##", "");
         s = s.replaceAll("##END##", "");
 
-        String name = s.substring(0, 9).trim();
-        String s2 = s.substring(10, 19).trim();
+        String name = s.substring(0, 10).trim();
+        String s2 = s.substring(10, 20).trim();
         String s3 = s.substring(20).trim();
 
         BigDecimal price = new BigDecimal(s2);

--- a/chapter3/transform/src/test/java/camelinaction/OrderToCsvBean.java
+++ b/chapter3/transform/src/test/java/camelinaction/OrderToCsvBean.java
@@ -7,9 +7,9 @@ package camelinaction;
 public class OrderToCsvBean {
 
     public String map(String custom) {
-        String id = custom.substring(0, 9);
-        String customerId = custom.substring(10, 19);
-        String date = custom.substring(20, 29);
+        String id = custom.substring(0, 10);
+        String customerId = custom.substring(10, 20);
+        String date = custom.substring(20, 30);
         String items = custom.substring(30);
         String[] itemIds = items.split("@");
 

--- a/chapter3/transform/src/test/java/camelinaction/OrderToCsvBeanTest.java
+++ b/chapter3/transform/src/test/java/camelinaction/OrderToCsvBeanTest.java
@@ -19,7 +19,7 @@ public class OrderToCsvBeanTest extends CamelTestSupport {
 
         // compare the expected file content
         String body = context.getTypeConverter().convertTo(String.class, file);
-        assertEquals("000000555,20091209,000001144,2319,1108", body);
+        assertEquals("0000005555,20091209,0000011441,2319,1108", body);
     }
 
     @Override

--- a/chapter3/transform/src/test/java/camelinaction/OrderToCsvProcessor.java
+++ b/chapter3/transform/src/test/java/camelinaction/OrderToCsvProcessor.java
@@ -12,9 +12,9 @@ public class OrderToCsvProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         String custom = exchange.getIn().getBody(String.class);
 
-        String id = custom.substring(0, 9);
-        String customerId = custom.substring(10, 19);
-        String date = custom.substring(20, 29);
+        String id = custom.substring(0, 10);
+        String customerId = custom.substring(10, 20);
+        String date = custom.substring(20, 30);
         String items = custom.substring(30);
         String[] itemIds = items.split("@");
 

--- a/chapter3/transform/src/test/java/camelinaction/OrderToCsvProcessorTest.java
+++ b/chapter3/transform/src/test/java/camelinaction/OrderToCsvProcessorTest.java
@@ -19,7 +19,7 @@ public class OrderToCsvProcessorTest extends CamelTestSupport {
 
         // compare the expected file content
         String body = context.getTypeConverter().convertTo(String.class, file);
-        assertEquals("000000444,20091208,000001212,1217,1478,2132", body);
+        assertEquals("0000004444,20091208,0000012123,1217,1478,2132", body);
     }
 
     @Override

--- a/chapter3/transform/src/test/java/camelinaction/SpringOrderToCsvBeanTest.java
+++ b/chapter3/transform/src/test/java/camelinaction/SpringOrderToCsvBeanTest.java
@@ -25,7 +25,7 @@ public class SpringOrderToCsvBeanTest extends CamelSpringTestSupport {
 
         // compare the expected file content
         String body = context.getTypeConverter().convertTo(String.class, file);
-        assertEquals("000000555,20091209,000001144,2319,1108", body);
+        assertEquals("0000005555,20091209,0000011441,2319,1108", body);
     }
 
 }

--- a/chapter3/transform/src/test/java/camelinaction/SpringOrderToCsvProcessorTest.java
+++ b/chapter3/transform/src/test/java/camelinaction/SpringOrderToCsvProcessorTest.java
@@ -25,6 +25,6 @@ public class SpringOrderToCsvProcessorTest extends CamelSpringTestSupport {
 
         // compare the expected file content
         String body = context.getTypeConverter().convertTo(String.class, file);
-        assertEquals("000000444,20091208,000001212,1217,1478,2132", body);
+        assertEquals("0000004444,20091208,0000012123,1217,1478,2132", body);
     }
 }


### PR DESCRIPTION
In the chapter 3 converter example there is an inhouse format transformed
to CSV. The implementation of the OrderToCsvBean and
the OrderToCsvProcessor will drop two characters and a
(insignificant) white space.

Example from the testOrderToCsvProcessor:

    test data   :  0000004444000001212320091208  1217@1478@2132
    string index:  01234567890123456789012345678901234567890123
    L for lost  :  .........L.........L.........L..............

Example from the testOrderToCsvBean:

    test data   :  0000005555000001144120091209  2319@1108
    string index:  012345678901234567890123456789012345678
    L for lost  :  .........L.........L.........L.........

Assuming that loosing information from the inhouse format is
unintentional, this commit may be a possible correction.