### PR TITLE
Citrus

### DIFF
--- a/chapter9/citrus/pom.xml
+++ b/chapter9/citrus/pom.xml
@@ -115,23 +115,22 @@
         </configuration>
       </plugin>
 
-      <!-- to run the integration tests -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19</version>
         <executions>
           <execution>
-            <id>citrus-tests</id>
-            <phase>integration-test</phase>
+            <id>integration-tests</id>
             <goals>
-              <goal>test</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/chapter9/citrus/src/test/java/camelinaction/CitrusIT.java
+++ b/chapter9/citrus/src/test/java/camelinaction/CitrusIT.java
@@ -17,8 +17,11 @@
 package camelinaction;
 
 import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.condition.AbstractCondition;
+import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.junit.JUnit4CitrusTestDesigner;
 import com.consol.citrus.jms.message.JmsMessageHeaders;
+import org.apache.camel.CamelContext;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 
@@ -49,6 +52,36 @@ public class CitrusIT extends JUnit4CitrusTestDesigner {
                 .payload("<order><id>123</id><status>In Progress</status></order>")
                 .contentType("text/xml")
                 .version("HTTP/1.1");
+
+        waitForGracefulShutdown();
+    }
+
+    /**
+     * Wait for graceful shutdown of Camel context before closing the test.
+     */
+    private void waitForGracefulShutdown() {
+        waitFor().condition(new AbstractCondition() {
+            @Override
+            public boolean isSatisfied(TestContext context) {
+                try {
+                    context.getApplicationContext().getBean(CamelContext.class).stop();
+                } catch (Exception e) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public String getSuccessMessage(TestContext context) {
+                return "Successfully stopped Camel context";
+            }
+
+            @Override
+            public String getErrorMessage(TestContext context) {
+                return "Failed to stop Camel context";
+            }
+        });
     }
 
 }


### PR DESCRIPTION
I made your Citrus integration test work with given Camel example. PR includes following changes:

- Use Maven failsafe plugin for Citrus test execution during Maven integration-test phase
- Add "fork" option to http-client send request action (This is because Citrus will synchronously wait for Http response and further test actions such as JMS receive-send are not executed without fork)
- Manually track JMSCorrelationId for synchronous JMS message so Camel route can correlate
- Wait for graceful Camel context shutdown (this is just for avoiding exceptions in log output during Camel context shutdown, when test is finished Camel context shutdown gets interrupted pretty rude)