### PR TITLE
User servlets 3.1 descriptor in arquillian-web example for jetty 9.2

### DIFF
--- a/chapter9/arquillian-web/src/main/webapp/WEB-INF/web.xml
+++ b/chapter9/arquillian-web/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,8 @@
-<web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<web-app version="3.1" metadata-complete="true"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
   <display-name>Quote Web Application</display-name>
 


### PR DESCRIPTION
@davsclaus @janstey I think we should latest versions of web.xml descriptors - 3.1 or at least 3.0.
3.1 works fine with Jetty 9.2.x