### PR TITLE
provide Camel routes with ids

### DIFF
--- a/chapter19/eclipse-camel-editor/src/main/resources/META-INF/spring/camel-context.xml
+++ b/chapter19/eclipse-camel-editor/src/main/resources/META-INF/spring/camel-context.xml
@@ -1,30 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Configures the Camel Context-->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-
-  <camelContext xmlns="http://camel.apache.org/schema/spring">
-    <!-- here is a sample which processes the input files
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+    <camelContext id="camelContext-41fb2403-e2fa-4748-9604-46b6ecf0b966" xmlns="http://camel.apache.org/schema/spring">
+        <!-- here is a sample which processes the input files
          (leaving them in place - see the 'noop' flag)
          then performs content based routing on the message using XPath -->
-    <route>
-      <from uri="file:src/data?noop=true"/>
-      <choice>
-        <when>
-          <xpath>/person/city = 'London'</xpath>
-          <log message="UK message"/>
-          <to uri="file:target/messages/uk"/>
-        </when>
-        <otherwise>
-          <log message="Other message"/>
-          <to uri="file:target/messages/others"/>
-        </otherwise>
-      </choice>
-    </route>
-  </camelContext>
-
+        <route id="exampleRoute">
+            <from id="fileTrigger" uri="file:src/data?noop=true"/>
+            <choice id="choiceCity">
+                <when id="whenLondon">
+                    <xpath>/person/city = 'London'</xpath>
+                    <log id="logUK" message="UK message"/>
+                    <to id="messageToUk" uri="file:target/messages/uk"/>
+                </when>
+                <otherwise id="otherCities">
+                    <log id="logOtherCity" message="Other message"/>
+                    <to id="messageToOther" uri="file:target/messages/others"/>
+                </otherwise>
+            </choice>
+        </route>
+    </camelContext>
 </beans>


### PR DESCRIPTION
- Fuse Tooling is enforcing usage of ids
- use the default formatting in Fuse Tooling