### PR TITLE
Specify Doctype to xml file without xsd or DTD

### DIFF
--- a/chapter19/eclipse-camel-editor/src/data/message1.xml
+++ b/chapter19/eclipse-camel-editor/src/data/message1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <person user="james">
   <firstName>James</firstName>
   <lastName>Strachan</lastName>

--- a/chapter19/eclipse-camel-editor/src/data/message2.xml
+++ b/chapter19/eclipse-camel-editor/src/data/message2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <person user="hiram">
   <firstName>Hiram</firstName>
   <lastName>Chirino</lastName>


### PR DESCRIPTION
- cleaner document
- avoids warnings in Eclipse