### PR TITLE
Adds missing Jackson dependencies for chapter 2 tests

### DIFF
--- a/chapter2/cbr/pom.xml
+++ b/chapter2/cbr/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/filter/pom.xml
+++ b/chapter2/filter/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/ftp-jms/pom.xml
+++ b/chapter2/ftp-jms/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/multicast/pom.xml
+++ b/chapter2/multicast/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/recipientlist/pom.xml
+++ b/chapter2/recipientlist/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/spring/pom.xml
+++ b/chapter2/spring/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/chapter2/wiretap/pom.xml
+++ b/chapter2/wiretap/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>activemq-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+
     <!-- xbean is needed for ActiveMQ broker XML configuration in Spring XML files -->
     <dependency>
       <groupId>org.apache.xbean</groupId>


### PR DESCRIPTION
Resolves runtime issue with chapter 2 tests by adding in missing Jackson dependency. Without this dependency, the tests do not correctly initialize leading to errors & failures.

*N.B. I have not checked tests beyond chapter 5 so do not know if this issue needs to be addressed in later chapter modules or not.*